### PR TITLE
Use 'in the past' vs. 'since last' to agree with all timeframes.

### DIFF
--- a/src/components/InfoColumn/index.js
+++ b/src/components/InfoColumn/index.js
@@ -8,8 +8,8 @@ import { calculatePercentageDiff, calculateDiff } from './utils';
 const calculateSubHeader = (rangeType = '') => {
   const formatStr = str => str.replace('_', ' ');
   return {
-    diffPPMSubHeader: `SINCE LAST ${rangeType ? formatStr(rangeType) : ''}`,
-    diffPercentSubHeader: `SINCE LAST ${
+    diffPPMSubHeader: `IN THE PAST ${rangeType ? formatStr(rangeType) : ''}`,
+    diffPercentSubHeader: `IN THE PAST ${
       rangeType ? formatStr(rangeType) : ''
     } (%)`,
   };

--- a/src/components/InfoColumn/tests/index.test.js
+++ b/src/components/InfoColumn/tests/index.test.js
@@ -21,9 +21,9 @@ describe('InfoColumnHOC Component', () => {
       const component = getComponent({ rangeType: ALL, currentPpm: 22 });
       expect(component.state()).toEqual({
         ppmDiff: 0,
-        diffPPMSubHeader: 'SINCE LAST ',
+        diffPPMSubHeader: 'IN THE PAST ',
         ppmPercentDiff: 0,
-        diffPercentSubHeader: 'SINCE LAST  (%)',
+        diffPercentSubHeader: 'IN THE PAST  (%)',
       }); // confirm initalstate
       component.setProps({
         rangeType: FIVE_YEAR,
@@ -32,9 +32,9 @@ describe('InfoColumnHOC Component', () => {
       });
       expect(component.state()).toEqual({
         ppmDiff: '+10.00 PPM',
-        diffPPMSubHeader: 'SINCE LAST five years',
+        diffPPMSubHeader: 'IN THE PAST five years',
         ppmPercentDiff: '+45.45 %',
-        diffPercentSubHeader: 'SINCE LAST five years (%)',
+        diffPercentSubHeader: 'IN THE PAST five years (%)',
       }); // confirm initalstate
     });
   });
@@ -42,9 +42,9 @@ describe('InfoColumnHOC Component', () => {
     const component = getComponent({ rangeType: ALL, currentPpm: 22 });
     expect(component.state()).toEqual({
       ppmDiff: 0,
-      diffPPMSubHeader: 'SINCE LAST ',
+      diffPPMSubHeader: 'IN THE PAST ',
       ppmPercentDiff: 0,
-      diffPercentSubHeader: 'SINCE LAST  (%)',
+      diffPercentSubHeader: 'IN THE PAST  (%)',
     }); // confirm initalstate
     component.setProps({
       rangeType: ALL,
@@ -53,9 +53,9 @@ describe('InfoColumnHOC Component', () => {
     });
     expect(component.state()).toEqual({
       ppmDiff: 0,
-      diffPPMSubHeader: 'SINCE LAST ',
+      diffPPMSubHeader: 'IN THE PAST ',
       ppmPercentDiff: 0,
-      diffPercentSubHeader: 'SINCE LAST  (%)',
+      diffPercentSubHeader: 'IN THE PAST  (%)',
     });
   });
 });


### PR DESCRIPTION
Fixes #168 