### PR TITLE
making team div scrollable

### DIFF
--- a/src/components/TeamItem/index.js
+++ b/src/components/TeamItem/index.js
@@ -2,17 +2,20 @@ import React from 'react';
 import { teamItems } from '../../constants';
 import './team.css';
 
-const TeamItem = ({ items }) =>
-  items.map(item => (
-    <div className="team-container">
-      <img src={item.src} className="team-image" alt={item.alt} />
-      <div className="team-content">
-        <p className="team-name">{item.name}</p>
-        <p className="team-position">{item.position}</p>
-        <p className="team-location">{item.location}</p>
+const TeamItem = ({ items }) => (
+  <div className="team-div">
+    {items.map(item => (
+      <div className="team-container">
+        <img src={item.src} className="team-image" alt={item.alt} />
+        <div className="team-content">
+          <p className="team-name">{item.name}</p>
+          <p className="team-position">{item.position}</p>
+          <p className="team-location">{item.location}</p>
+        </div>
       </div>
-    </div>
-  ));
+    ))}
+  </div>
+);
 
 TeamItem.defaultProps = { items: teamItems };
 

--- a/src/components/TeamItem/team.css
+++ b/src/components/TeamItem/team.css
@@ -24,3 +24,8 @@
   flex-direction: row;
   align-items: center;
 }
+
+.team-div {
+  max-height: 500px;
+  overflow: auto;
+}

--- a/src/components/TeamItem/team.css
+++ b/src/components/TeamItem/team.css
@@ -26,6 +26,6 @@
 }
 
 .team-div {
-  max-height: 500px;
+  max-height: 450px;
   overflow: auto;
 }


### PR DESCRIPTION
fixes #182 

created a new css class 'team-div' and gave it the 'overflow: auto' style, then attributed that class to the team component body.