### PR TITLE
Update development API endpoints.

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -3,10 +3,10 @@ const environment = {
     apiEndpoint: 'http://127.0.0.1:8000',
   },
   development: {
-    apiEndpoint: 'https://carbondoomsday-test.herokuapp.com',
+    apiEndpoint: 'https://api-test.carbondoomsday.com',
   },
   staging: {
-    apiEndpoint: 'https://carbondoomsday-test.herokuapp.com',
+    apiEndpoint: 'https://api-test.carbondoomsday.com',
   },
   production: {
     apiEndpoint: 'https://carbondoomsday.herokuapp.com',


### PR DESCRIPTION
I'm not 100% sure this PR is necessary, but I wasn't able to get my local server to work without these changes. I didn't update the production endpoint, but I'm curious as to why the production server is pulling from api.carbondoomsday.com when the URL in `src/config/index.js` is the herokuapp.com URL.